### PR TITLE
WIP add option for gpg.program to git config

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -41,17 +41,25 @@ pub fn is_ancestor(base_ref: &str, remote_ref: &str) -> Result<bool> {
     Ok(result.status.success())
 }
 
-pub fn config(setting: &str) -> Result<String> {
+pub fn config2(setting: &str, default: &str) -> Result<String> {
     let result = Command::new("git")
         .arg("config")
         .arg(setting)
         .output()
         .chain_err(|| "failed to run git")?;
     if !result.status.success() {
-        bail!("git config failed");
+        return Ok(default.to_string());
     }
     let s = String::from_utf8(result.stdout).chain_err(|| "not utf8")?;
-    Ok(s.trim().to_string())
+    return Ok(s.trim().to_string());
+}
+
+pub fn config(setting: &str) -> Result<String> {
+    let ret = config2(setting, "")?;
+    if ret == "" {
+        bail!("git config failed");
+    }
+    return Ok(ret);
 }
 
 pub fn rev_parse(rev: &str) -> Result<String> {

--- a/src/gpg.rs
+++ b/src/gpg.rs
@@ -2,8 +2,8 @@ use super::errors::*;
 use std::path::Path;
 use std::process::Command;
 
-pub fn encrypt(recipients: &[String], i: &Path, o: &Path) -> Result<()> {
-    let mut cmd = Command::new("gpg");
+pub fn encrypt(recipients: &[String], i: &Path, o: &Path, gpgcmd: &String) -> Result<()> {
+    let mut cmd = Command::new(gpgcmd);
     cmd.arg("-q").arg("--batch");
     for recipient in recipients {
         cmd.arg("-r").arg(recipient);
@@ -22,8 +22,8 @@ pub fn encrypt(recipients: &[String], i: &Path, o: &Path) -> Result<()> {
     Ok(())
 }
 
-pub fn decrypt(i: &Path, o: &Path) -> Result<()> {
-    let result = Command::new("gpg")
+pub fn decrypt(i: &Path, o: &Path, gpgcmd: &String) -> Result<()> {
+    let result = Command::new(gpgcmd)
         .arg("-q")
         .arg("--batch")
         .arg("-o")


### PR DESCRIPTION
Thank you for the useful program. 

Apologies for the slightly ugly PR, this is my first time using Rust. One day I'll understand why method chains have to end in question marks to compile, but for now I'm moving on to other tasks.

This PR parameterizes the gpg command to be used, using the `gpg.program` git config setting or defaulting to `gpg` if not set. 

To do so required refactoring the config function to optionally take a default value. I feel like this refactor feels "backwards" and that config + defaults should delegate to config w/o, but this is what I was able to get to compile.

I've tested it with the following shell script for gpg.program, which is able to push/pull cleartext from s3

```
#!/bin/bash
echo "trying $* "  >&2

if test "$5" == "-d"; then
    cat <"$6" >"$4"
else
    cat <"$8" >"$6"
fi
```

Ultimately, I will need to cross-build this for windows (which uses "gpg.exe", among other differences) ; I'll post here if I'm able to get that working.

